### PR TITLE
Add button / keyboard styles

### DIFF
--- a/_sass/minimal-mistakes.scss
+++ b/_sass/minimal-mistakes.scss
@@ -38,3 +38,6 @@
 @import "minimal-mistakes/archive";
 @import "minimal-mistakes/sidebar";
 @import "minimal-mistakes/print";
+
+/* Custom button / keyboard styles */
+@import "minimal-mistakes/keyboard"

--- a/_sass/minimal-mistakes/keyboard.scss
+++ b/_sass/minimal-mistakes/keyboard.scss
@@ -1,0 +1,25 @@
+kbd {
+	padding: 3px 6px;
+	font: 11px SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
+	line-height: 10px;
+	color: #fafbfc;
+	vertical-align: middle;
+	background-color: #6a747e;
+	border: 1px solid #475057;
+	border-radius: 6px;
+	box-shadow: inset 0 -1px 0 #475057;
+}
+
+kbd.l {
+	border-radius: 15px 6px 6px 6px;
+	padding-left: 8px;
+}
+
+kbd.r {
+	border-radius: 6px 15px 6px 6px;
+	padding-right: 8px;
+}
+
+kbd.face {
+	border-radius: 15px;
+}


### PR DESCRIPTION
This adds styles for buttons / keyboard, the default is basically GitHub's but dark theme, with the class `face` (for face buttons) its a circle, then with the class `l` and `r` they have angled corners:
![スクリーンショット 2020-09-08 23 46 08](https://user-images.githubusercontent.com/41608708/92556632-13a2a680-f230-11ea-838d-46d705de72ab.png)
